### PR TITLE
Support redirecting from legacy (pre Betty 0.5) entity URLs

### DIFF
--- a/betty_nginx/assets/nginx.conf.j2
+++ b/betty_nginx/assets/nginx.conf.j2
@@ -10,6 +10,20 @@ add_header Vary Accept-Language;
 {% endif %}
 {% endmacro %}
 
+{% if project.extensions["nginx"].configuration.legacy_entity_redirects %}
+    map $uri $legacy_entity_redirect {
+        default "none";
+        {% set url_path_prefix -%}
+            {% if project.configuration.locales.multilingual -%}
+                /{{ project.configuration.locales.values() | map(attribute="alias")| join("|") }}
+            {%- endif %}
+        {%- endset %}
+        {% for entity in project.ancestry if entity.plugin.public_facing %}
+            ~^({{ url_path_prefix }})?/{{ entity.plugin.id }}/{{ entity.id }}(\/.*)*$ $1/{{ entity.plugin.id }}/{{ entity.public_id }}$2;
+        {% endfor %}
+    }
+{% endif %}
+
 {% if https %}
     server {
         listen 80;
@@ -47,6 +61,13 @@ server {
         set $media_type_extension html;
     {% endif %}
     index index.$media_type_extension;
+
+    {% if project.extensions["nginx"].configuration.legacy_entity_redirects %}
+        if ($legacy_entity_redirect != "none") {
+            rewrite ^ $legacy_entity_redirect permanent;
+        }
+    {% endif %}
+
 
     {% if project.configuration.locales.multilingual %}
         location @localized_redirect {

--- a/betty_nginx/config.py
+++ b/betty_nginx/config.py
@@ -27,6 +27,11 @@ class NginxConfiguration(Configuration):
     whether the project's URL uses HTTPS or not.
     """
 
+    legacy_entity_redirects: bool
+    """
+    Whether to generate redirects from legacy (pre Betty 0.5) entity URLs.
+    """
+
     www_directory_path: str | None
     """
     The nginx server's public web root directory path.
@@ -37,10 +42,12 @@ class NginxConfiguration(Configuration):
         *,
         www_directory_path: str | None = None,
         https: bool | None = None,
+        legacy_entity_redirects: bool = False,
     ):
         super().__init__()
         self.https = https
         self.www_directory_path = www_directory_path
+        self.legacy_entity_redirects = legacy_entity_redirects
 
     @override
     def load(self, dump: Dump) -> None:
@@ -53,6 +60,10 @@ class NginxConfiguration(Configuration):
                 "www_directory",
                 assert_str() | assert_setattr(self, "www_directory_path"),
             ),
+            OptionalField(
+                "legacy_entity_redirects",
+                assert_bool() | assert_setattr(self, "legacy_entity_redirects"),
+            ),
         )(dump)
 
     @override
@@ -60,6 +71,8 @@ class NginxConfiguration(Configuration):
         dump: DumpMapping[Dump] = {
             "https": self.https,
         }
+        if self.legacy_entity_redirects:
+            dump["legacy_entity_redirects"] = True
         if self.www_directory_path is not None:
             dump["www_directory"] = str(self.www_directory_path)
         return dump

--- a/betty_nginx/tests/test_config.py
+++ b/betty_nginx/tests/test_config.py
@@ -37,6 +37,14 @@ class TestNginxConfiguration:
         sut.load(dump)
         assert sut.https == https
 
+    async def test_load__with_legacy_entity_redirects(self) -> None:
+        dump: Dump = {
+            "legacy_entity_redirects": True,
+        }
+        sut = NginxConfiguration()
+        sut.load(dump)
+        assert sut.legacy_entity_redirects
+
     async def test_load__with_www_directory(self) -> None:
         www_directory = "/var/www"
         dump: Dump = {
@@ -50,6 +58,15 @@ class TestNginxConfiguration:
         sut = NginxConfiguration()
         expected = {
             "https": None,
+        }
+        assert sut.dump() == expected
+
+    async def test_dump__with_legacy_entity_redirects(self) -> None:
+        sut = NginxConfiguration()
+        sut.legacy_entity_redirects = True
+        expected = {
+            "https": None,
+            "legacy_entity_redirects": True,
         }
         assert sut.dump() == expected
 

--- a/betty_nginx/tests/test_integration.py
+++ b/betty_nginx/tests/test_integration.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import html5lib
 import pytest
 import requests
+from betty.ancestry import Ancestry
 from betty.ancestry.place import Place
 from betty.app import App
 from betty.functools import Do
@@ -32,12 +33,14 @@ from betty_nginx.serve import DockerizedNginxServer
 class TestNginx:
     @asynccontextmanager
     async def server(
-        self, configuration: ProjectConfiguration
+        self, configuration: ProjectConfiguration, *, ancestry: Ancestry | None = None
     ) -> AsyncIterator[Server]:
         async with (
             App.new_temporary() as app,
             app,
-            Project.new_temporary(app, configuration=configuration) as project,
+            Project.new_temporary(
+                app, ancestry=ancestry, configuration=configuration
+            ) as project,
             project,
         ):
             await generate.generate(project)
@@ -145,10 +148,10 @@ class TestNginx:
         )
 
     def _build_assert_status_code(
-        self, http_status_code: int
+        self, expected_http_status_code: int
     ) -> Callable[[Response], None]:
         def _assert(response: Response) -> None:
-            assert http_status_code == response.status_code
+            assert response.status_code == expected_http_status_code
 
         return _assert
 
@@ -328,4 +331,40 @@ class TestNginx:
             ).until(
                 self._build_assert_status_code(404),
                 self.assert_betty_json,
+            )
+
+    async def test_legacy_entity_redirects__monolingual(
+        self, monolingual_configuration: ProjectConfiguration
+    ):
+        monolingual_configuration.extensions[Nginx].configuration[  # type: ignore[call-overload,index]
+            "legacy_entity_redirects"
+        ] = True
+        ancestry = Ancestry()
+        entity = Place(id="my-first-place")
+        ancestry.add(entity)
+        async with self.server(monolingual_configuration, ancestry=ancestry) as server:
+            await Do(
+                requests.get,
+                f"{server.public_url}/{entity.plugin.id}/{entity.id}/index.html",
+            ).until(
+                self._build_assert_status_code(200),
+                self.assert_betty_html,
+            )
+
+    async def test_legacy_entity_redirects__multilingual(
+        self, multilingual_configuration: ProjectConfiguration
+    ):
+        multilingual_configuration.extensions[Nginx].configuration[  # type: ignore[call-overload,index]
+            "legacy_entity_redirects"
+        ] = True
+        ancestry = Ancestry()
+        entity = Place(id="my-first-place")
+        ancestry.add(entity)
+        async with self.server(multilingual_configuration, ancestry=ancestry) as server:
+            await Do(
+                requests.get,
+                f"{server.public_url}/en/{entity.plugin.id}/{entity.id}/index.html",
+            ).until(
+                self._build_assert_status_code(200),
+                self.assert_betty_html,
             )


### PR DESCRIPTION
This fixes https://github.com/bartfeenstra/betty-nginx/issues/72